### PR TITLE
Specify a 'default' texture for the quad

### DIFF
--- a/derez/mesh/quad.mesh
+++ b/derez/mesh/quad.mesh
@@ -1,4 +1,4 @@
 material: "/derez/mesh/quad.material"
 vertices: "/derez/mesh/quad.buffer"
-textures: ""
+textures: "/builtins/assets/images/logo/logo_blue_256.png"
 primitive_type: PRIMITIVE_TRIANGLES


### PR DESCRIPTION
The compiler was very sad that the `quad.mesh` didn't have it's texture specified D:
```
/derez/mesh/quad.mesh
you must specify a texture
```

So I've set it to be the same one as in `/example/quad.mesh`: `/builtins/assets/images/logo/logo_blue_256.png`
Everything still renders as expected, the texture is instantly overwritten and is never seen.

I started using this engine like 6 hours ago, so please let me know if I was at fault for it not working :3